### PR TITLE
Do not detect features in comments

### DIFF
--- a/src/detector.ts
+++ b/src/detector.ts
@@ -9,6 +9,7 @@ import type {
   Plugin,
   DetectionOptions,
 } from "./types";
+import { scrubCode } from "./scrubCode";
 
 export class Detector {
   private compiledPatterns: Map<string, string>; // Store pattern strings instead of RegExp
@@ -65,22 +66,28 @@ export class Detector {
   }
 
   detectBoolean(code: string): boolean {
-    const hasStringMatch = this.checkStrings(code);
+    const scrubbed = scrubCode(code);
+
+    const hasStringMatch = this.checkStrings(scrubbed);
     if (hasStringMatch) {
       return true;
     }
 
-    const shouldCheckPatterns = this.shouldRunPatternDetection(code);
+    const shouldCheckPatterns = this.shouldRunPatternDetection(scrubbed);
     if (!shouldCheckPatterns) {
       return false;
     }
 
-    const hasPatternMatch = this.checkPatterns(code);
+    const hasPatternMatch = this.checkPatterns(scrubbed);
     return hasPatternMatch;
   }
 
   detectFast(code: string): DetectionResult {
-    const stringMatch = this.findFirstStringMatch(code);
+    const scrubbed = scrubCode(code);
+
+    console.log(scrubbed)
+
+    const stringMatch = this.findFirstStringMatch(scrubbed);
     if (stringMatch) {
       return {
         hasMatch: true,
@@ -89,7 +96,7 @@ export class Detector {
       };
     }
 
-    const shouldCheckPatterns = this.shouldRunPatternDetection(code);
+    const shouldCheckPatterns = this.shouldRunPatternDetection(scrubbed);
     if (!shouldCheckPatterns) {
       return {
         hasMatch: false,
@@ -97,7 +104,7 @@ export class Detector {
       };
     }
 
-    const patternMatch = this.findFirstPatternMatch(code);
+    const patternMatch = this.findFirstPatternMatch(scrubbed);
     if (patternMatch) {
       return {
         hasMatch: true,
@@ -113,7 +120,9 @@ export class Detector {
   }
 
   detectDetailed(code: string): DetectionResult {
-    const stringMatch = this.findFirstStringMatchDetailed(code);
+    const scrubbed = scrubCode(code);
+
+    const stringMatch = this.findFirstStringMatchDetailed(scrubbed);
     if (stringMatch) {
       return {
         hasMatch: true,
@@ -122,7 +131,7 @@ export class Detector {
       };
     }
 
-    const shouldCheckPatterns = this.shouldRunPatternDetection(code);
+    const shouldCheckPatterns = this.shouldRunPatternDetection(scrubbed);
     if (!shouldCheckPatterns) {
       return {
         hasMatch: false,
@@ -130,7 +139,7 @@ export class Detector {
       };
     }
 
-    const patternMatch = this.findFirstPatternMatchDetailed(code);
+    const patternMatch = this.findFirstPatternMatchDetailed(scrubbed);
     if (patternMatch) {
       return {
         hasMatch: true,

--- a/src/scrubCode.ts
+++ b/src/scrubCode.ts
@@ -1,0 +1,94 @@
+/**
+ * The scrubCode removes parts of code, which could lead to false positives (strings and comments).
+ */
+export const scrubCode = (code: string) => {
+  const result: string[] = [];
+
+  // regex for /* // " ' tokens
+  const modeRegex = /(?:(?:\/\*)|(?:\/\/)|(?:")|(?:'))/g;
+
+  let position = 0;
+  let state: ["code"] | ["string", "'" | '"'] | ["comment", "//" | "/*"] = [
+    "code",
+  ];
+
+  loop: while (position < code.length) {
+    switch (state[0]) {
+      case "code": {
+        modeRegex.lastIndex = position;
+        const nextToken = modeRegex.exec(code);
+
+        if (nextToken === null) break loop;
+
+        result.push(code.slice(position, nextToken.index));
+
+        switch (nextToken[0]) {
+          case "/*":
+            state = ["comment", "/*"];
+            break;
+          case "//":
+            state = ["comment", "//"];
+            break;
+          case "'":
+            state = ["string", "'"];
+            break;
+          case '"':
+            state = ["string", '"'];
+            break;
+        }
+        position = nextToken.index;
+
+        break;
+      }
+      case "string": {
+        const token = state[1];
+        const endIndex = code.indexOf(token, position + 1);
+
+        if (endIndex === -1) {
+          throw new Error(`Invalid input at ${position}`);
+        }
+
+        result.push(token + " ".repeat(endIndex - position - 1) + token);
+        position = endIndex + 1;
+        state = ["code"];
+
+        break;
+      }
+      case "comment": {
+        const endToken = state[1] === "/*" ? "*/" : "\n";
+
+        let endIndex = code.indexOf(endToken, position + 2);
+
+        if (endIndex === -1) {
+          endIndex = code.length;
+        }
+
+        if (endToken === "\n") {
+          result.push(
+            " ".repeat(endIndex + endToken.length - position - 1) + "\n",
+          );
+        } else {
+          result.push(
+            getWhitespace(code.slice(position, endIndex + endToken.length)),
+          );
+        }
+
+        position = endIndex === -1 ? code.length : endIndex + endToken.length;
+
+        state = ["code"];
+
+        break;
+      }
+    }
+  }
+
+  result.push(code.slice(position));
+
+  return result.join("");
+};
+
+const getWhitespace = (comment: string) =>
+  comment
+    .split("\n")
+    .map((ln) => " ".repeat(ln.length))
+    .join("\n");

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -56,6 +56,42 @@ describe("fast-brake main API", () => {
       const result = await fastBrake(code);
       expect(result.length).toBeGreaterThan(0);
     });
+
+    test("should parse comments", async () => {
+      const code = `(function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(1);
+
+
+/***/ })
+`;
+
+      const result = await fastBrake(code);
+      expect(result).toEqual([]);
+    });
+
+    test.only("should ignore single-line comments", async () => {
+      const code = `// same as const x = 4;
+var x = 4;
+
+// same as const y = 2;
+var y = 2;
+
+// same as x ** y
+Math.pow(x, y);
+
+// comment without trailing empty line () => "test"`;
+
+      const result = await fastBrake(code);
+      expect(result).toEqual([]);
+    });
+
+    test("should ignore multi-line comments", async () => {
+      const code = `/** [1,2,3,4].map(x => x ** 2) */`;
+
+      const result = await fastBrake(code);
+      expect(result).toEqual([]);
+    });
   });
 
   describe("detect function", () => {

--- a/tests/unit/scrubCode.test.ts
+++ b/tests/unit/scrubCode.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { scrubCode } from "../../src/scrubCode";
+
+describe("scrubCode", () => {
+  test("it should remove comments and strings", () => {
+    const code = `
+// same as const x = 4;
+var x = 4;
+
+/* hello */
+console.log("hello");
+
+// same as const y = 2;
+var y = 2;
+
+// same as x ** y
+Math.pow(x, y);
+
+// () => "test"
+
+/* end of file */
+`;
+
+    expect(scrubCode(code)).toEqual(`
+                       
+var x = 4;
+
+           
+console.log("     ");
+
+                       
+var y = 2;
+
+                 
+Math.pow(x, y);
+
+               
+
+                 
+`);
+  });
+
+  test("shouldn't move code", () => {
+    const code = `
+/* *** */ var x = 0;
+    `;
+
+    expect(scrubCode(code).indexOf("var x")).toBe(code.indexOf("var x"));
+  });
+
+  test("it should emit code before and after the commit", async () => {
+    const code = `
+var beforeComment = true;
+// comment
+beforeComment = false;`;
+
+    expect(scrubCode(code)).toEqual(`
+var beforeComment = true;
+          
+beforeComment = false;`);
+  });
+
+  test("it should preserve newlines in multiline comments", () => {
+    const code = `
+/* Line1
+Line2
+Line3
+*/
+`;
+
+    expect(scrubCode(code)).toEqual(`
+        
+     
+     
+  
+`);
+  });
+
+  test("trailing comment", () => {
+    const code = `var x = 5;
+// comment`;
+
+    expect(scrubCode(code)).toEqual(`var x = 5;
+          
+`);
+  });
+});


### PR DESCRIPTION
This is mostly a draft and I'm more than happy to make any adjustments/fixes. Newer versions of es-check (and fast-brake) are matching language features in comments, which means that a valid es5 code will be marked as invalid. This is very easy to encounter, because /** is considered an exponentiation operator. 

Comments should to be replaced with whitespace, so their content won't get matched, but it keeps all other code at the same location. This is similar to "Strip types only" option in swc.

Similar approach should be also taken for strings because `var x = "() => {}";` will get matched as well